### PR TITLE
fix: multiple display enhancements

### DIFF
--- a/src/components/frequently-used-mirror-card.tsx
+++ b/src/components/frequently-used-mirror-card.tsx
@@ -37,10 +37,10 @@ export default function FrequentlyUsedMirrorCard({ name, icon, desc, url }: Freq
               justifyContent="flex-start"
               alignItems="center"
             >
-              <Typography variant="h6" component="div">
+              <Typography variant="h6" component="div" textAlign="center">
                 {name}
               </Typography>
-              <Typography variant="body2" color="text.secondary">
+              <Typography variant="body2" color="text.secondary" textAlign="center">
                 {desc}
               </Typography>
             </Grid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,11 +29,11 @@ interface Data {
 const networkMap = {
   0: {
     text: '校外网络',
-    color: 'info',
+    color: 'primary',
   },
   1: {
     text: '校内网络 - IPv4',
-    color: 'primary',
+    color: 'success',
   },
   2: {
     text: '校内网络 - IPv6',
@@ -138,6 +138,7 @@ const Index =  ({ data }: { data: Data }) => {
           </Typography>
           <Typography variant="subtitle1" component="div" color="primary">
             <Chip
+              size="small"
               label={t(networkMap[networkMode].text)}
               color={networkMap[networkMode].color}
             />

--- a/src/templates/mirror-doc.tsx
+++ b/src/templates/mirror-doc.tsx
@@ -80,20 +80,17 @@ const MirrorDoc = ({ data }: { data: Data }) => {
           >
             <Grid item sx={{ width: "100%" }}>
               <Grid container justifyContent="space-between">
-                <Typography variant="h5" component="div" color="primary">
-                  <Trans>ZJU Mirror</Trans>
-                </Typography>
+                <Link color="primary" underline="hover" to="/">
+                  <Typography variant="h5" component="div" color="primary">
+                    <Trans>ZJU Mirror</Trans>
+                  </Typography>
+                </Link>
                 <Grid item>
                   <LanguageIconButton />
                   <ThemeIconButton />
                 </Grid>
               </Grid>
-              <Link color="primary" underline="hover" to="/" sx={{ mt: 4, display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-                <ArrowBack sx={{ fontSize: "1em", mr: .5 }} />
-                <Typography variant="subtitle1">
-                  <Trans>返回</Trans>
-                </Typography>
-              </Link>
+              <Box sx={{ mt: 4, display: 'flex', flexDirection: 'row', alignItems: 'center' }}/>
 
               <Typography variant="h2" fontWeight={400} component="div">
                 {name}
@@ -135,7 +132,7 @@ const MirrorDoc = ({ data }: { data: Data }) => {
             {!data.document.frontmatter?.isGit && <Grid item>
               <Button
                 color="primary"
-                size="large"
+                size="medium"
                 variant="contained"
                 startIcon={<FolderIcon />}
                 to={mirrorUrl}
@@ -146,9 +143,6 @@ const MirrorDoc = ({ data }: { data: Data }) => {
           </Grid>
         </Box>
         <Paper sx={{ p: { xs: 4, sm: 8 } }} elevation={0}>
-          <Typography gutterBottom variant="h5" component="div">
-            <Trans>使用说明</Trans>
-          </Typography>
           <MDXProvider components={components}>
             <MDXRenderer>{data.document.body}</MDXRenderer>
           </MDXProvider>


### PR DESCRIPTION
- add `textAlign="center"` for frequently-used mirror card  
![image](https://user-images.githubusercontent.com/19510622/178110550-f8d4e2e8-e9a7-4f1b-8113-a8c9984f80be.png)

- make network clip smaller, change color
![image](https://user-images.githubusercontent.com/19510622/178110632-d5bbbfde-0951-427c-80d8-e92d84ef856b.png)

- rm `返回` button and `使用说明` title text in doc page
- make `文件列表` button smaller