### PR TITLE
Fix whitespace in code block

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -27,7 +27,6 @@ export default function CodeBlock({ children, codeStyle, ...props }: CodeBlockPr
           padding: 20,
           overflowX: 'auto',
           borderRadius: 5,
-          whiteSpace: 'nowrap',
           ...style,
           ...codeStyle
         }}>


### PR DESCRIPTION
Whitespaces were collapsed in code blocks because of a wrong CSS rule.