### PR TITLE
doc: fix RaspberryPi version description and config mismatch

### DIFF
--- a/docs/zh/raspberrypi.mdx
+++ b/docs/zh/raspberrypi.mdx
@@ -4,7 +4,7 @@ mirrorId: raspberrypi
 
 import ConfigGenerator from '../../src/components/config-generator'
 
-export const osVersion = ['9', '10', '11'];
+export const osVersion = ['11', '10', '9'];
 export const versionName = [
     'Debian 11 (bullseye)',
     'Debian 10 (buster)',


### PR DESCRIPTION
<img width="616" alt="截屏2023-06-12 08 27 13" src="https://github.com/ZJUSCT/mirror-front/assets/37043529/1ee9e683-d542-4931-97f3-994725c0880a">

"bullseye" showing "stretch" configuration and vice versa