### PR TITLE
Fix raspbian version-name mapping

### DIFF
--- a/docs/zh/raspbian.mdx
+++ b/docs/zh/raspbian.mdx
@@ -24,7 +24,7 @@ testing 版本的 7.0/wheezy，所以 Raspbian 不倾向于使用 stable/testing
 
 #### armv7l
 
-export const osVersion = ['9', '10', '11'];
+export const osVersion = ['11', '10', '9'];
 export const versionName = [
     'Debian 11 (bullseye)',
     'Debian 10 (buster)',


### PR DESCRIPTION
以下段落来自 @tonyluj 的邮件：

# 复现方法
1. 打开：http://mirrors.zju.edu.cn/docs/raspbian/ 或 http://mirrors.zju.edu.cn/docs/raspberrypi/
2. 在“版本选择”下拉框中，如果选择的为 Debian 11，文本框中被错误的填充为 stretch