### PR TITLE
fix: fix doc break after upgraded prism-react-renderer to v2

### DIFF
--- a/docs/zh/docker-ce.mdx
+++ b/docs/zh/docker-ce.mdx
@@ -46,7 +46,7 @@ sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-pr
 
 根据你的发行版，下面的内容有所不同。你使用的发行版： 
 
-<ConfigGenerator promptString="选择你使用的发行版：" versionList={osList} defaultVersion={'Debian'} configGen={genCommand} />
+<ConfigGenerator promptString="选择你使用的发行版：" versionList={osList} defaultVersion={'Debian'} language="bash" configGen={genCommand} />
 
 #### Fedora/CentOS/RHEL
 
@@ -66,7 +66,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 
 根据你的发行版下载repo文件: 
 
-<ConfigGenerator promptString="选择你使用的发行版：" versionList={osList2} defaultVersion={'CentOS/RHEL'} configGen={genCommand2} />
+<ConfigGenerator promptString="选择你使用的发行版：" versionList={osList2} defaultVersion={'CentOS/RHEL'} language="bash" configGen={genCommand2} />
 
 把软件仓库地址替换为浙大源:
 

--- a/docs/zh/elrepo.mdx
+++ b/docs/zh/elrepo.mdx
@@ -27,6 +27,7 @@ rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
     promptString="" 
     versionList={osVersion}
     friendlyNameList={versionName}
+    language="bash"
     configGen={configGen} />
 
 接下来是换源，建议先备份 `/etc/yum.repos.d/elrepo.repo` ：

--- a/docs/zh/raspberrypi.mdx
+++ b/docs/zh/raspberrypi.mdx
@@ -27,4 +27,5 @@ export const configGen = (version) => {
     promptString="" 
     versionList={osVersion}
     friendlyNameList={versionName}
+    language=""
     configGen={configGen} />

--- a/docs/zh/raspbian.mdx
+++ b/docs/zh/raspbian.mdx
@@ -49,6 +49,7 @@ deb [arch=arm64] https://mirrors.zju.edu.cn/raspbian/multiarch/ ${release_name} 
     promptString="" 
     versionList={osVersion}
     friendlyNameList={versionName}
+    language=""
     configGen={configGen} />
 
 


### PR DESCRIPTION
`prism-react-renderer` requires "language" prop in v2, we upgraded to v2 in #95