### PR TITLE
Remove MikTeX from CTAN doc

### DIFF
--- a/docs/zh/CTAN.mdx
+++ b/docs/zh/CTAN.mdx
@@ -2,12 +2,14 @@
 mirrorId: CTAN
 ---
 
+> 本站 CTAN 镜像暂不支持 MikTeX 发行版。
+
 CTAN (The Comprehensive TeX Archive Network) 是所有 TeX 排版系统相关材料的汇集地，收录了编译引擎、宏包及字体等的源代码与说明文档。目前，绝大多数 LaTeX 宏包会被上传至 CTAN 核心站点，随后同步到遍布全球的各个镜像。
 
 - CTAN 主页： https://www.ctan.org/
 - 浙江大学镜像： https://mirrors.zju.edu.cn/CTAN/
 
-本文提供了 TeX Live 和 MiKTeX 两大主要发行版的镜像配置方法。
+本文提供了 TeX Live 的镜像配置方法。
 
 ### TeX Live
 
@@ -45,19 +47,3 @@ tlmgr update --all --repository https://mirrors.zju.edu.cn/CTAN/systems/texlive/
 ```
 
 其中的 ```update --all``` 指令可根据需要修改。
-
-### MiKTeX
-
-MiKTeX 发行版的特点在于仅安装用户需要的宏包，节省了磁盘空间占用，但在部分实现细节上与 TeX Live 有所出入。该发行版支持 Windows、Linux 和 macOS。
-
-#### 安装
-
-MiKTeX 仅提供 Windows 和 macOS 的独立安装包，前往 TeX 排版系统下载页即可。在 Linux 下的安装请参考[官方文档](https://miktex.org/howto/install-miktex-unx)。
-
-#### 切换镜像
-
-MiKTeX 使用的 CTAN 镜像源可以从内置的 MiKTeX Console 图形化应用程序进行切换，也可以使用如下命令：
-
-```bash
-mpm --set-repository=https://mirrors.zju.edu.cn/CTAN/systems/win32/miktex/tm/packages/
-```


### PR DESCRIPTION
We're currently not listed in `https://api2.miktex.org/repositories/${md5}`. To avoid confusion for our users, MikTeX instructions should be removed for now.