### PR TITLE
feat: add relative time display for mirror updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "gatsby-source-filesystem": "^5.14.0",
         "i18next": "^22.5.1",
         "js-search": "^2.0.1",
+        "moment": "^2.30.1",
         "natsort": "^2.0.3",
         "path-to-regexp": "^6.3.0",
         "prism-react-renderer": "^2.4.1",
@@ -19931,7 +19932,7 @@
     },
     "node_modules/moment": {
       "version": "2.30.1",
-      "resolved": "https://registry.npmmirror.com/moment/-/moment-2.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gatsby-source-filesystem": "^5.14.0",
     "i18next": "^22.5.1",
     "js-search": "^2.0.1",
+    "moment": "^2.30.1",
     "natsort": "^2.0.3",
     "path-to-regexp": "^6.3.0",
     "prism-react-renderer": "^2.4.1",

--- a/src/templates/mirror-doc.tsx
+++ b/src/templates/mirror-doc.tsx
@@ -5,6 +5,8 @@ import Skeleton from '@mui/material/Skeleton';
 import Paper from '@mui/material/Paper';
 import { graphql } from 'gatsby';
 import { Trans, useI18next } from 'gatsby-plugin-react-i18next';
+import moment from 'moment';
+import 'moment/locale/zh-cn';
 import { LinkButton as Button } from '~/components/link-mui-components';
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 import Footer from '../components/footer';
@@ -41,6 +43,14 @@ async function fetchMirror(id: string): Promise<MirrorDto> {
 
 const MirrorDoc = ({ data, children }: PropsWithChildren<MirrorDocProps>) => {
   const { language } = useI18next();
+
+  // Use browser locale for moment on client side
+  useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      const browserLocale = navigator.language?.toLowerCase();
+      if (browserLocale) moment.locale(browserLocale);
+    }
+  }, []);
 
   const defaultData = {
     id: data.document.frontmatter.mirrorId,
@@ -140,7 +150,8 @@ const MirrorDoc = ({ data, children }: PropsWithChildren<MirrorDocProps>) => {
                         language
                       ),
                     }}
-                  </Trans>
+                  </Trans>{' '}
+                  ({moment(mirror.lastUpdated * 1000).fromNow()})
                 </Typography>
               </Grid>
             </Grid>


### PR DESCRIPTION
This patch uses moment.js and read locale from current browser session (as we don't have English documents for now)

Locale `zh-cn`:
<img width="646" height="283" alt="image" src="https://github.com/user-attachments/assets/89e26f52-e8d6-4492-8f64-2071a92e2407" />

Locale `en`:
<img width="624" height="272" alt="image" src="https://github.com/user-attachments/assets/7b0985f5-5d6a-464e-977b-8b51c0a9a51d" />
