### PR TITLE
docs: update docker-ce for debian trixie

### DIFF
--- a/docs/zh/docker-ce.mdx
+++ b/docs/zh/docker-ce.mdx
@@ -25,9 +25,16 @@ for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker c
 sudo apt-get install apt-transport-https ca-certificates curl gnupg2 software-properties-common
 ```
 
-根据你的发行版，下面的内容有所不同。你使用的发行版： 
+然后添加软件源，这一步不同发行版不同。
 
 <ConfigGen config={debianGenConf} generatorFunc={debianGenFunc} />
+
+最后安装相关软件包：
+
+```bash
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
 
 #### Fedora/CentOS/RHEL/AlmaLinux/Rocky Linux
 


### PR DESCRIPTION
- Adjusted Debian/Ubuntu Docker CE instructions to store the mirror GPG key as `docker.asc`.
- Replaced the old `docker.list` entry with a `.sources` file using VERSION_CODENAME for suite selection.

See https://docs.docker.com/engine/install/debian/#install-using-the-repository
